### PR TITLE
Improve test docstrings with clearer checks and failure cases

### DIFF
--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -7,7 +7,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../s
 from app import get_metric_info
 
 def test_get_metric_info_returns_revenue_settings():
-    """get_metric_info returns the correct settings for revenue metric."""
+    """get_metric_info returns the correct settings for revenue metric.
+    This test checks metric mapping and formatting; 
+    it would fail if revenue configuration changes or is mis-specified."""
     result = get_metric_info("total_revenue")
 
     assert result["id"] == "total_revenue"
@@ -18,7 +20,9 @@ def test_get_metric_info_returns_revenue_settings():
 
 
 def test_get_metric_info_returns_order_settings():
-    """get_metric_info returns the correct settings for order metric."""
+    """get_metric_info returns the correct settings for order metric.
+    This test checks aggregation and labels; 
+    it would fail if order metric logic or aggregation function changes."""
     result = get_metric_info("order_id")
 
     assert result["id"] == "order_id"
@@ -28,7 +32,9 @@ def test_get_metric_info_returns_order_settings():
     assert result["agg_func"] == "nunique"
 
 def test_get_metric_info_contains_required_keys():
-    """get_metric_info returns dictionary with required keys."""
+    """get_metric_info returns dictionary with required keys.
+    This test checks output structure; 
+    it would fail if expected keys are missing or renamed."""
     result = get_metric_info("total_revenue")
 
     expected_keys = {"id", "label", "exact_format", "short", "agg_func"}
@@ -37,7 +43,9 @@ def test_get_metric_info_contains_required_keys():
 
 
 def test_get_metric_info_unknown_metric_defaults_to_order_logic():
-    """get_metric_info treats unknown metrics as order-based metric."""
+    """get_metric_info treats unknown metrics as order-based metric.
+    This test checks default fallback behavior; 
+    it would fail if unknown metrics are not handled consistently."""
     result = get_metric_info("unknown_metric")
 
     assert result["label"] == "Total Orders"

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -8,13 +8,18 @@ APP_PATH = Path(__file__).resolve().parents[1] / "src" / "app.py"
 app = create_app_fixture(APP_PATH)
 
 def get_checked_values(page: Page, input_name: str) -> list[str]:
-    """Return the currently selected values of a checkbox group input."""
+    """get_metric_info returns correct configuration for revenue metric.
+    This test checks returned fields and values; 
+    it would fail if metric mapping or formatting logic changes."""
     return page.locator(f'input[name="{input_name}"]:checked').evaluate_all(
         "els => els.map(el => el.value)"
     )
     
 def test_year_filter_selection_changes(page: Page, app: ShinyAppProc) -> None:
-    """Selecting a single year updates the year checkbox selection."""
+    """Selecting a year updates the checkbox selection state.
+    This test checks that only the selected year is active; 
+    it would fail if input binding or UI state syncing breaks."""
+
     page.goto(app.url)
 
     year_input = controller.InputCheckboxGroup(page, "input_year")
@@ -26,7 +31,10 @@ def test_year_filter_selection_changes(page: Page, app: ShinyAppProc) -> None:
 
 
 def test_region_filter_updates_dashboard_outputs(page: Page, app: ShinyAppProc) -> None:
-    """Selecting one region limits the dashboard summaries to the chosen region."""
+    """Selecting one region updates dashboard outputs (revenue and orders) to reflect that region only.
+    This test checks that value boxes change after selection; 
+    it would fail if filtering logic or reactive outputs break."""
+
     page.goto(app.url)
 
     region_input = controller.InputCheckboxGroup(page, "input_region")
@@ -42,7 +50,9 @@ def test_region_filter_updates_dashboard_outputs(page: Page, app: ShinyAppProc) 
     expect(orders_box).not_to_have_text(orders_before)
 
 def test_season_switch_toggle(page: Page, app: ShinyAppProc) -> None:
-    """The season switch input can be toggled on and off."""
+    """The season switch can toggle between on and off states.
+    This test checks the switch state updates correctly; 
+    it would fail if input control or state binding breaks."""
     page.goto(app.url)
 
     season_input = controller.InputSwitch(page, "input_season")
@@ -54,7 +64,9 @@ def test_season_switch_toggle(page: Page, app: ShinyAppProc) -> None:
     season_input.expect_checked(True)
 
 def test_metric_filter_updates_selection(page: Page, app: ShinyAppProc) -> None:
-    """Selecting a different metric updates the radio button input."""
+    """Selecting a different metric updates the radio button selection.
+    This test checks that the selected metric changes correctly; 
+    it would fail if input control or selection logic breaks."""
     page.goto(app.url)
 
     metric_input = controller.InputRadioButtons(page, "input_metric")
@@ -64,7 +76,9 @@ def test_metric_filter_updates_selection(page: Page, app: ShinyAppProc) -> None:
     metric_input.expect_selected("order_id")
 
 def test_reset_button_restores_defaults(page: Page, app: ShinyAppProc) -> None:
-    """Clicking reset restores year and region filters to default selections."""
+    """Clicking reset restores filters to their default selections.
+    This test checks that year and region inputs return to default values; 
+    it would fail if reset logic or default state handling breaks."""
     page.goto(app.url)
 
     year_input = controller.InputCheckboxGroup(page, "input_year")
@@ -82,7 +96,9 @@ def test_reset_button_restores_defaults(page: Page, app: ShinyAppProc) -> None:
     assert "Asia" in regions
 
 def test_metric_change_updates_valuebox(page: Page, app: ShinyAppProc) -> None:
-    """Changing the metric updates the value box output."""
+    """Changing the metric updates the value box output.
+    This test checks that displayed values change when metric changes; 
+    it would fail if aggregation or reactive rendering breaks."""
     page.goto(app.url)
 
     metric_input = controller.InputRadioButtons(page, "input_metric")


### PR DESCRIPTION
## Summary
Added more detailed docstrings to tests to clarify what is being checked and what could break.

## Changes
- Updated Playwright test descriptions to include failure cases
- Updated `get_metric_info` tests to explain expected behavior and edge cases
- No changes to app logic

## Note
All tests pass with `pytest`